### PR TITLE
Provide python2 at build time

### DIFF
--- a/org.widelands.Widelands.yaml
+++ b/org.widelands.Widelands.yaml
@@ -15,8 +15,14 @@ finish-args:
   # OpenGL access
   - --device=dri
 cleanup:
+  - /bin/pip*
+  - /bin/python*
+  - /bin/smtpd.py
   - /include
+  - /lib/debug/source/python*
+  - /lib/libpython*
   - /lib/pkgconfig
+  - /lib/python*
   - /share/man
   - '*.la'
   - '*.a'
@@ -24,6 +30,7 @@ modules:
   - shared-modules/lua5.3/lua-5.3.5.json
   - shared-modules/glu/glu-9.json
   - shared-modules/glew/glew.json
+  - shared-modules/python2.7/python-2.7.json
 
   - name: boost
     buildsystem: simple


### PR DESCRIPTION
Python 2 is required by `utils/*.py`. These scripts may be used by CMake at build time to update and validate translations, copyright, authors, AppData, etc. as well as to detect game version/revision.
Some of them (but not all of them) are compatible with Python 3. However, Widelands expect that there will be the `python` executable, which unfortunately isn't true for Freedesktop >= `19.08`.